### PR TITLE
Name value for Paypal

### DIFF
--- a/frontend/src/pages/Checkout.tsx
+++ b/frontend/src/pages/Checkout.tsx
@@ -944,7 +944,7 @@ const Checkout = () => {
                           <div className="payment-options-container">
                             <PayPalButtons
                               createOrder={async () => {
-                                const name = `${car.name} - ${daysLabel} - ${pickupLocation._id === dropOffLocation._id ? pickupLocation.name : `${pickupLocation.name} - ${dropOffLocation.name}`}`
+                                const name = `${car.name}`
                                 const amount = payDeposit ? depositPrice : price
                                 const orderId = await PayPalService.createOrder(bookingId!, amount, PaymentService.getCurrency(), name)
                                 return orderId

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,9 +2,9 @@
   "expo": {
     "jsEngine": "hermes",
     "newArchEnabled": true,
-    "name": "Sicarro",
+    "name": "BookCars",
     "version": "5.6.0",
-    "slug": "sicarro",
+    "slug": "bookcars",
     "icon": "./assets/icon.png",
     "assetBundlePatterns": [
       "**/*"
@@ -19,18 +19,24 @@
         "foregroundImage": "./assets/icon.png"
       },
       "icon": "./assets/icon.png",
+      // "splash": {
+      //   "backgroundColor": "#f37022",
+      //   "image": "./assets/splash.png"
+      // },
       "googleServicesFile": "./google-services.json",
       "softwareKeyboardLayoutMode": "pan",
-      "package": "com.sicarro"
+      "package": "com.bookcars"
     },
     "ios": {
       "buildNumber": "5.6.0",
       "supportsTablet": true,
       "icon": "./assets/icon.png",
-      "bundleIdentifier": "com.sicarro",
-      "infoPlist": {
-        "ITSAppUsesNonExemptEncryption": false
-      }
+      // "splash": {
+      //   "backgroundColor": "#f37022",
+      //   "image": "./assets/splash.png",
+      //   "tabletImage": "./assets/splash-tablet.png"
+      // },
+      "bundleIdentifier": "com.bookcars"
     },
     "plugins": [
       "expo-localization",
@@ -44,20 +50,27 @@
         }
       ],
       [
+        "@stripe/stripe-react-native",
+        {
+          "merchantIdentifier": "MERCHANT_IDENTIFIER",
+          "enableGooglePay": true
+        }
+      ],
+      [
         "expo-document-picker",
         {
           "iCloudContainerEnvironment": "Production"
         }
       ]
     ],
-    "owner": "guillermopaz",
+    "owner": "aelassas",
     "extra": {
       "eas": {
-        "projectId": "ecdecc8f-1b81-4571-b3fe-1edbb69c2ce3"
+        "projectId": "fe1ab335-41ae-4a35-960b-0052b493db49"
       }
     },
     "updates": {
-      "url": "https://u.expo.dev/ecdecc8f-1b81-4571-b3fe-1edbb69c2ce3"
+      "url": "https://u.expo.dev/fe1ab335-41ae-4a35-960b-0052b493db49"
     },
     "experiments": {
       "tsconfigPaths": true

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,9 +2,9 @@
   "expo": {
     "jsEngine": "hermes",
     "newArchEnabled": true,
-    "name": "BookCars",
+    "name": "Sicarro",
     "version": "5.6.0",
-    "slug": "bookcars",
+    "slug": "sicarro",
     "icon": "./assets/icon.png",
     "assetBundlePatterns": [
       "**/*"
@@ -19,24 +19,18 @@
         "foregroundImage": "./assets/icon.png"
       },
       "icon": "./assets/icon.png",
-      // "splash": {
-      //   "backgroundColor": "#f37022",
-      //   "image": "./assets/splash.png"
-      // },
       "googleServicesFile": "./google-services.json",
       "softwareKeyboardLayoutMode": "pan",
-      "package": "com.bookcars"
+      "package": "com.sicarro"
     },
     "ios": {
       "buildNumber": "5.6.0",
       "supportsTablet": true,
       "icon": "./assets/icon.png",
-      // "splash": {
-      //   "backgroundColor": "#f37022",
-      //   "image": "./assets/splash.png",
-      //   "tabletImage": "./assets/splash-tablet.png"
-      // },
-      "bundleIdentifier": "com.bookcars"
+      "bundleIdentifier": "com.sicarro",
+      "infoPlist": {
+        "ITSAppUsesNonExemptEncryption": false
+      }
     },
     "plugins": [
       "expo-localization",
@@ -50,27 +44,20 @@
         }
       ],
       [
-        "@stripe/stripe-react-native",
-        {
-          "merchantIdentifier": "MERCHANT_IDENTIFIER",
-          "enableGooglePay": true
-        }
-      ],
-      [
         "expo-document-picker",
         {
           "iCloudContainerEnvironment": "Production"
         }
       ]
     ],
-    "owner": "aelassas",
+    "owner": "guillermopaz",
     "extra": {
       "eas": {
-        "projectId": "fe1ab335-41ae-4a35-960b-0052b493db49"
+        "projectId": "ecdecc8f-1b81-4571-b3fe-1edbb69c2ce3"
       }
     },
     "updates": {
-      "url": "https://u.expo.dev/fe1ab335-41ae-4a35-960b-0052b493db49"
+      "url": "https://u.expo.dev/ecdecc8f-1b81-4571-b3fe-1edbb69c2ce3"
     },
     "experiments": {
       "tsconfigPaths": true


### PR DESCRIPTION
The "name" value is violating PayPal’s schema if it more than ~200+ characters long. Resulting an error 400.

Request:

        "items": [
          {
            "name": "Mitsubishi L200 - \n  3 días (Thu, 6 Feb 2025, 10:00 AM \n  - Sun, 9 Feb 2025, 10:00 AM) - Aeropuerto Internacional de El Salvador, Oscar Arnulfo Romero y Galdámez",
            "description": "Mitsubishi L200 - \n  3 días (Thu, 6 Feb 2025, 10:00 AM \n  - Sun, 9 Feb 2025, 10:00 AM) - Aeropuerto Internacional de El Salvador, Oscar Arnulfo Romero y Galdámez",
            "unit_amount": {
              "currency_code": "USD",
              "value": "15.00"
            },
            "quantity": "1"
          }
        ]

Response:

      {
        "field": "/purchase_units/@reference_id=='default'/items/0/name",
        "value": "xxxxxx",
        "location": "body",
        "issue": "INVALID_STRING_LENGTH",
        "description": "The value of a field is either too short or too long."
      }