### PR TITLE
Optimize pre-commit hook to lint and type-check only changed projects with Docker fallback

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,2 @@
 #!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-echo "🔧 Running lint and type-check on all projects..."
-
 npm run pre-commit


### PR DESCRIPTION
This PR optimizes the `pre-commit` hook to significantly speed up the commit process by:

- Linting only the changed `.ts`, `.tsx`, `.js`, `.jsx` files in their respective projects
- Running TypeScript type-check only for projects that have staged file changes
- Adding automatic fallback to Docker if local lint/type-check fails
- Detecting if already running inside Docker and skipping fallback to avoid nesting
- Skipping checks gracefully if no Docker container is configured (e.g., mobile project)

## Improvements

- Faster pre-commit execution by targeting only modified files/projects
- More reliable checks in environments without local Node.js tools (Docker fallback)
- Better developer experience with cleaner logs
- Reduced unnecessary Docker operations when committing small changes

## Notes

- Full type-check still runs for changed projects to ensure cross-file issues are caught
- Projects without any staged changes are skipped entirely (no lint, no type-check)
- No external npm packages were introduced; pure Node.js

---

✅ Faster commits  
✅ Smarter fallback handling  
✅ Clear and readable logs  
✅ Zero new dependencies
