### PR TITLE
fix(docker): correct API log volume path in docker-compose files

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -38,7 +38,7 @@ services:
       - cdn:/var/www/cdn/bookcars
       - ./api:/bookcars/api
       - /bookcars/api/node_modules
-      - api_logs:/wexcommerce/api/logs
+      - api_logs:/bookcars/api/logs
 
   bc-dev-backend:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - mongo
     volumes:
       - cdn:/var/www/cdn/bookcars
-      - api_logs:/wexcommerce/api/logs
+      - api_logs:/bookcars/api/logs
 
   bc-backend:
     build: 


### PR DESCRIPTION
The volume path for the API logs was incorrectly set in both `docker-compose.yml` and `docker-compose.dev.yml`, which caused log files to not persist correctly.

### Changes
 Updated `/wexcommerce/api/logs` to `/bookcars/api/logs` in both compose files.